### PR TITLE
Fixing two sources of crashes loading some SVG files

### DIFF
--- a/svgd.go
+++ b/svgd.go
@@ -424,20 +424,19 @@ func (c *IconCursor) readStyleAttr(curStyle *PathStyle, k, v string) error {
 			curStyle.LineJoin = rasterx.Bevel
 		}
 	case "stroke-miterlimit":
-		mLimit, err := strconv.ParseFloat(v, 64)
+		mLimit, err := parseFloat(v, 64)
 		if err != nil {
 			return err
 		}
 		curStyle.MiterLimit = mLimit
 	case "stroke-width":
-		v = strings.TrimSuffix(v, "px")
-		width, err := strconv.ParseFloat(v, 64)
+		width, err := parseFloat(v, 64)
 		if err != nil {
 			return err
 		}
 		curStyle.LineWidth = width
 	case "stroke-dashoffset":
-		dashOffset, err := strconv.ParseFloat(v, 64)
+		dashOffset, err := parseFloat(v, 64)
 		if err != nil {
 			return err
 		}
@@ -447,7 +446,7 @@ func (c *IconCursor) readStyleAttr(curStyle *PathStyle, k, v string) error {
 			dashes := splitOnCommaOrSpace(v)
 			dList := make([]float64, len(dashes))
 			for i, dstr := range dashes {
-				d, err := strconv.ParseFloat(strings.TrimSpace(dstr), 64)
+				d, err := parseFloat(strings.TrimSpace(dstr), 64)
 				if err != nil {
 					return err
 				}
@@ -457,7 +456,7 @@ func (c *IconCursor) readStyleAttr(curStyle *PathStyle, k, v string) error {
 			break
 		}
 	case "opacity", "stroke-opacity", "fill-opacity":
-		op, err := strconv.ParseFloat(v, 64)
+		op, err := parseFloat(v, 64)
 		if err != nil {
 			return err
 		}
@@ -510,14 +509,24 @@ func (c *IconCursor) PushStyle(attrs []xml.Attr) error {
 
 // unitSuffixes are suffixes sometimes applied to the width and height attributes
 // of the svg element.
-var unitSuffixes = [3]string{"cm", "mm", "px"}
+var unitSuffixes = []string{"cm", "mm", "px", "pt"}
 
+// trimSuffixes removes unitSuffixes from any number that is not just numeric
 func trimSuffixes(a string) (b string) {
+	if a == "" || (a[len(a)-1] >= '0' && a[len(a)-1] <= '9') {
+		return a
+	}
 	b = a
 	for _, v := range unitSuffixes {
 		b = strings.TrimSuffix(b, v)
 	}
 	return
+}
+
+// parseFloat is a helper function that strips suffixes before passing to strconv.ParseFloat
+func parseFloat(s string, bitSize int) (float64, error) {
+	val := trimSuffixes(s)
+	return strconv.ParseFloat(val, bitSize)
 }
 
 // splitOnCommaOrSpace returns a list of strings after splitting the input on comma and space delimiters
@@ -665,7 +674,7 @@ func readFraction(v string) (f float64, err error) {
 		d = 100
 		v = strings.TrimSuffix(v, "%")
 	}
-	f, err = strconv.ParseFloat(v, 64)
+	f, err = parseFloat(v, 64)
 	f /= d
 	if f > 1 {
 		f = 1
@@ -755,11 +764,9 @@ var (
 				c.icon.ViewBox.W = c.points[2]
 				c.icon.ViewBox.H = c.points[3]
 			case "width":
-				wn := trimSuffixes(attr.Value)
-				width, err = strconv.ParseFloat(wn, 64)
+				width, err = parseFloat(attr.Value, 64)
 			case "height":
-				hn := trimSuffixes(attr.Value)
-				height, err = strconv.ParseFloat(hn, 64)
+				height, err = parseFloat(attr.Value, 64)
 			}
 			if err != nil {
 				return err
@@ -780,17 +787,17 @@ var (
 		for _, attr := range attrs {
 			switch attr.Name.Local {
 			case "x":
-				x, err = strconv.ParseFloat(attr.Value, 64)
+				x, err = parseFloat(attr.Value, 64)
 			case "y":
-				y, err = strconv.ParseFloat(attr.Value, 64)
+				y, err = parseFloat(attr.Value, 64)
 			case "width":
-				w, err = strconv.ParseFloat(attr.Value, 64)
+				w, err = parseFloat(attr.Value, 64)
 			case "height":
-				h, err = strconv.ParseFloat(attr.Value, 64)
+				h, err = parseFloat(attr.Value, 64)
 			case "rx":
-				rx, err = strconv.ParseFloat(attr.Value, 64)
+				rx, err = parseFloat(attr.Value, 64)
 			case "ry":
-				ry, err = strconv.ParseFloat(attr.Value, 64)
+				ry, err = parseFloat(attr.Value, 64)
 			}
 			if err != nil {
 				return err
@@ -808,16 +815,16 @@ var (
 		for _, attr := range attrs {
 			switch attr.Name.Local {
 			case "cx":
-				cx, err = strconv.ParseFloat(attr.Value, 64)
+				cx, err = parseFloat(attr.Value, 64)
 			case "cy":
-				cy, err = strconv.ParseFloat(attr.Value, 64)
+				cy, err = parseFloat(attr.Value, 64)
 			case "r":
-				rx, err = strconv.ParseFloat(attr.Value, 64)
+				rx, err = parseFloat(attr.Value, 64)
 				ry = rx
 			case "rx":
-				rx, err = strconv.ParseFloat(attr.Value, 64)
+				rx, err = parseFloat(attr.Value, 64)
 			case "ry":
-				ry, err = strconv.ParseFloat(attr.Value, 64)
+				ry, err = parseFloat(attr.Value, 64)
 			}
 			if err != nil {
 				return err
@@ -835,13 +842,13 @@ var (
 		for _, attr := range attrs {
 			switch attr.Name.Local {
 			case "x1":
-				x1, err = strconv.ParseFloat(attr.Value, 64)
+				x1, err = parseFloat(attr.Value, 64)
 			case "x2":
-				x2, err = strconv.ParseFloat(attr.Value, 64)
+				x2, err = parseFloat(attr.Value, 64)
 			case "y1":
-				y1, err = strconv.ParseFloat(attr.Value, 64)
+				y1, err = parseFloat(attr.Value, 64)
 			case "y2":
-				y2, err = strconv.ParseFloat(attr.Value, 64)
+				y2, err = parseFloat(attr.Value, 64)
 			}
 			if err != nil {
 				return err
@@ -1000,7 +1007,7 @@ var (
 					//todo: add current color inherit
 					stop.StopColor, err = ParseSVGColor(attr.Value)
 				case "stop-opacity":
-					stop.Opacity, err = strconv.ParseFloat(attr.Value, 64)
+					stop.Opacity, err = parseFloat(attr.Value, 64)
 				}
 				if err != nil {
 					return err
@@ -1021,9 +1028,9 @@ var (
 			case "href":
 				href = attr.Value
 			case "x":
-				x, err = strconv.ParseFloat(attr.Value, 64)
+				x, err = parseFloat(attr.Value, 64)
 			case "y":
-				y, err = strconv.ParseFloat(attr.Value, 64)
+				y, err = parseFloat(attr.Value, 64)
 			}
 			if err != nil {
 				return err

--- a/svgd.go
+++ b/svgd.go
@@ -444,7 +444,7 @@ func (c *IconCursor) readStyleAttr(curStyle *PathStyle, k, v string) error {
 		curStyle.DashOffset = dashOffset
 	case "stroke-dasharray":
 		if v != "none" {
-			dashes := strings.Split(v, ",")
+			dashes := splitOnCommaOrSpace(v)
 			dList := make([]float64, len(dashes))
 			for i, dstr := range dashes {
 				d, err := strconv.ParseFloat(strings.TrimSpace(dstr), 64)
@@ -518,6 +518,14 @@ func trimSuffixes(a string) (b string) {
 		b = strings.TrimSuffix(b, v)
 	}
 	return
+}
+
+// splitOnCommaOrSpace returns a list of strings after splitting the input on comma and space delimiters
+func splitOnCommaOrSpace(s string) []string {
+	return strings.FieldsFunc(s,
+		func(r rune) bool {
+			return r == ',' || r == ' '
+	})
 }
 
 func (c *IconCursor) readStartElement(se xml.StartElement) (err error) {

--- a/svgp.go
+++ b/svgp.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"log"
 	"math"
-	"strconv"
 	"unicode"
 
 	"github.com/srwiley/rasterx"
@@ -94,7 +93,7 @@ func (c *PathCursor) ReadFloat(numStr string) error {
 				isFirst = false
 				continue
 			}
-			f, err := strconv.ParseFloat(numStr[last:i], 64)
+			f, err := parseFloat(numStr[last:i], 64)
 			if err != nil {
 				return err
 			}
@@ -102,7 +101,7 @@ func (c *PathCursor) ReadFloat(numStr string) error {
 			last = i
 		}
 	}
-	f, err := strconv.ParseFloat(numStr[last:], 64)
+	f, err := parseFloat(numStr[last:], 64)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
One issue was stroke-dasharray values like "5 4", using spaces instead of commas.
The other was a "pt" unit type. I added a utility function to catch every float parse :)