### PR TITLE
Getters and setters for SvgPath fillerColor and linerColor

### DIFF
--- a/svgd.go
+++ b/svgd.go
@@ -178,7 +178,7 @@ func (svgp *SvgPath) GetLineColor() color.Color {
 	return getColor(svgp.linerColor)
 }
 
-func (svgp *SvgPath) SetFillColor(clr color.Color) color.Color {
+func (svgp *SvgPath) SetFillColor(clr color.Color) {
 	svgp.fillerColor = clr
 }
 

--- a/svgd.go
+++ b/svgd.go
@@ -170,18 +170,22 @@ func (svgp *SvgPath) DrawTransformed(r *rasterx.Dasher, opacity float64, t raste
 	}
 }
 
+// GetFillColor returns the fill color of the SvgPath if one is defined and otherwise returns colornames.Black
 func (svgp *SvgPath) GetFillColor() color.Color {
 	return getColor(svgp.fillerColor)
 }
 
+// GetLineColor returns the stroke color of the SvgPath if one is defined and otherwise returns colornames.Black
 func (svgp *SvgPath) GetLineColor() color.Color {
 	return getColor(svgp.linerColor)
 }
 
+// SetFillColor sets the fill color of the SvgPath
 func (svgp *SvgPath) SetFillColor(clr color.Color) {
 	svgp.fillerColor = clr
 }
 
+// SetLineColor sets the line color of the SvgPath
 func (svgp *SvgPath) SetLineColor(clr color.Color) {
 	svgp.linerColor = clr
 }

--- a/svgd.go
+++ b/svgd.go
@@ -170,12 +170,20 @@ func (svgp *SvgPath) DrawTransformed(r *rasterx.Dasher, opacity float64, t raste
 	}
 }
 
-func (svgp *SvgPath) GetFillerColor() color.Color {
+func (svgp *SvgPath) GetFillColor() color.Color {
 	return getColor(svgp.fillerColor)
 }
 
-func (svgp *SvgPath) GetLinerColor() color.Color {
+func (svgp *SvgPath) GetLineColor() color.Color {
 	return getColor(svgp.linerColor)
+}
+
+func (svgp *SvgPath) SetFillColor(clr color.Color) color.Color {
+	svgp.fillerColor = clr
+}
+
+func (svgp *SvgPath) SetLineColor(clr color.Color) {
+	svgp.linerColor = clr
 }
 
 // ParseSVGColorNum reads the SFG color string e.g. #FBD9BD

--- a/svgd.go
+++ b/svgd.go
@@ -170,6 +170,14 @@ func (svgp *SvgPath) DrawTransformed(r *rasterx.Dasher, opacity float64, t raste
 	}
 }
 
+func (svgp *SvgPath) GetFillerColor() color.Color {
+	return getColor(svgp.fillerColor)
+}
+
+func (svgp *SvgPath) GetLinerColor() color.Color {
+	return getColor(svgp.linerColor)
+}
+
 // ParseSVGColorNum reads the SFG color string e.g. #FBD9BD
 func ParseSVGColorNum(colorStr string) (r, g, b uint8, err error) {
 	colorStr = strings.TrimPrefix(colorStr, "#")


### PR DESCRIPTION
I noticed that fillerColor and linerColor are not accessible and added getters and setters as I needed it for my own project. My usecase involves creating patterns with different colors using an svg as a template for a pattern and found oksvg to be really useful with these added functions.

I did not see any contribution guidelines but thought these functions might be useful for others. Let me know if there is anything I need to change and if you would like me to add tests for these.