### PR TITLE
Fix panic on invalid color

### DIFF
--- a/svgd.go
+++ b/svgd.go
@@ -200,6 +200,7 @@ func ParseSVGColorNum(colorStr string) (r, g, b uint8, err error) {
 	var t uint64
 	if len(colorStr) != 6 || len(colorStr) != 3 {
 		err = fmt.Errorf("invalid length of color: '%s' (should be 3 or 6)", colorStr)
+		return
 	}
 	if len(colorStr) != 6 {
 		// SVG specs say duplicate characters in case of 3 digit hex number

--- a/svgd.go
+++ b/svgd.go
@@ -198,7 +198,7 @@ func (svgp *SvgPath) SetLineColor(clr color.Color) {
 func ParseSVGColorNum(colorStr string) (r, g, b uint8, err error) {
 	colorStr = strings.TrimPrefix(colorStr, "#")
 	var t uint64
-	if len(colorStr) != 6 && len(colorStr) != 3 {
+	if len(colorStr) != 6 || len(colorStr) != 3 {
 		err = fmt.Errorf("invalid length of color: '%s' (should be 3 or 6)", colorStr)
 	}
 	if len(colorStr) != 6 {

--- a/svgd.go
+++ b/svgd.go
@@ -198,6 +198,9 @@ func (svgp *SvgPath) SetLineColor(clr color.Color) {
 func ParseSVGColorNum(colorStr string) (r, g, b uint8, err error) {
 	colorStr = strings.TrimPrefix(colorStr, "#")
 	var t uint64
+	if len(colorStr) != 6 && len(colorStr) != 3 {
+		err = fmt.Errorf("invalid length of color: '%s' (should be 3 or 6)", colorStr)
+	}
 	if len(colorStr) != 6 {
 		// SVG specs say duplicate characters in case of 3 digit hex number
 		colorStr = string([]byte{colorStr[0], colorStr[0],

--- a/svgd.go
+++ b/svgd.go
@@ -580,6 +580,10 @@ func (c *IconCursor) PushStyle(attrs []xml.Attr) error {
 			pairs = append(pairs, attr.Name.Local+":"+attr.Value)
 		}
 	}
+	if len(c.StyleStack) == 0 {
+		return fmt.Errorf("invalid stylestack")	
+	}
+	
 	// Make a copy of the top style
 	curStyle := c.StyleStack[len(c.StyleStack)-1]
 	for _, pair := range pairs {


### PR DESCRIPTION
I used this package to scrape some SVGs and then convert them to PNG. As it happens, I ran across an invalid SVG, with een colorString of "#". This caused a panic. 

Since only colorStrings with a length of 6 and 3 are valid, I return the function with an error if the colorString doesn't meet this requirement.

Edit: adding another fix as well. It fixes a panic on an empty c.StyleStack.