### PR TITLE
fix: Support top level style tag.

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -32,6 +32,7 @@ var (
 		"path":           pathF,
 		"desc":           descF,
 		"defs":           defsF,
+		"style":          styleF,
 		"title":          titleF,
 		"linearGradient": linearGradientF,
 		"radialGradient": radialGradientF,
@@ -212,6 +213,10 @@ var (
 	}
 	defsF svgFunc = func(c *IconCursor, attrs []xml.Attr) error {
 		c.inDefs = true
+		return nil
+	}
+	styleF svgFunc = func(c *IconCursor, attrs []xml.Attr) error {
+		c.inDefsStyle = true
 		return nil
 	}
 	linearGradientF svgFunc = func(c *IconCursor, attrs []xml.Attr) error {

--- a/icon_cursor.go
+++ b/icon_cursor.go
@@ -342,6 +342,9 @@ func (c *IconCursor) readStartElement(se xml.StartElement) (err error) {
 		})
 		return nil
 	}
+	if se.Name.Local == "style" {
+		return nil
+	}
 	df, ok := drawFuncs[se.Name.Local]
 	if !ok {
 		errStr := "Cannot process svg element " + se.Name.Local

--- a/icon_cursor.go
+++ b/icon_cursor.go
@@ -342,9 +342,6 @@ func (c *IconCursor) readStartElement(se xml.StartElement) (err error) {
 		})
 		return nil
 	}
-	if se.Name.Local == "style" {
-		return nil
-	}
 	df, ok := drawFuncs[se.Name.Local]
 	if !ok {
 		errStr := "Cannot process svg element " + se.Name.Local

--- a/svgdraw_test.go
+++ b/svgdraw_test.go
@@ -204,6 +204,14 @@ func TestBadColor(t *testing.T) {
 	}
 }
 
+func TestTopLevelStyle(t *testing.T) {
+	// Test that a top level style tag without enclosing defs is supported
+	_, errSvg := ReadIcon("testdata/TopLevelStyle.svg", StrictErrorMode)
+	if errSvg != nil {
+		t.Error("failed to support top level style tag")
+	}
+}
+
 func TestClassesIcon(t *testing.T) {
 	SaveIcon(t, "testdata/TestClasses.svg")
 

--- a/testdata/TopLevelStyle.svg
+++ b/testdata/TopLevelStyle.svg
@@ -1,0 +1,12 @@
+<!--<?xml version="1.0" encoding="utf-8"?>-->
+
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 361.75 332.99">
+    <style>
+        .cls-1,.cls-2{fill:white;}.cls-3{fill:orange;}
+    </style>
+    <rect class="cls-1" x="0" y="0" width="300" height="200"/>
+    <circle class="cls-3" cx="174.81" cy="70.32" r="14.03"/>
+    <circle class="cls-2" cx="182.12" cy="66.88" r="3.15"/>
+    <circle class="cls-3" cx="243.17" cy="58.02" r="14.03"/>
+    <circle class="cls-2" cx="250.48" cy="54.57" r="3.15"/>
+</svg>


### PR DESCRIPTION
I have a working implementation that supports top level `style` tags and is tested. It is based on my comments in #34.

This feels a bit hacky, since I'm circumventing the `defs` handling. @srwiley what do you think?