### PR TITLE
fix: scale with one parameter

### DIFF
--- a/icon_cursor.go
+++ b/icon_cursor.go
@@ -140,7 +140,7 @@ func (c *IconCursor) readTransformAttr(m1 rasterx.Matrix2D, k string) (rasterx.M
 		}
 	case "scale":
 		if ln == 1 {
-			m1 = m1.Scale(c.points[0], 0)
+			m1 = m1.Scale(c.points[0], c.points[0])
 		} else if ln == 2 {
 			m1 = m1.Scale(c.points[0], c.points[1])
 		} else {


### PR DESCRIPTION
This image did not work:
``` svg
<svg xmlns="http://www.w3.org/2000/svg" width="90" height="90" viewBox="0 0 90 90" fill="none">
    <g transform="scale(2)">
        <circle cx="16" cy="15" r="11" fill="#000000"/>
    </g>
</svg>
```

SVG specification:
> The `scale(<x> [<y>])` transform function specifies a scale operation by x and y. If y is not provided, it is assumed to be equal to x.